### PR TITLE
feat: add client-side request caching

### DIFF
--- a/guia-turistica-frontend/src/lib/cache.ts
+++ b/guia-turistica-frontend/src/lib/cache.ts
@@ -1,0 +1,38 @@
+export type CachedEntry<T> = {
+  expiry: number;
+  data: T;
+};
+
+const cache = new Map<string, CachedEntry<unknown>>();
+const DEFAULT_TTL = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Retrieve a cached value or fetch it using the provided function.
+ * @param key unique cache key
+ * @param fetcher async function that returns the data to cache
+ * @param ttl time-to-live in ms (defaults to 5 minutes)
+ * @param force if true, bypasses cache and fetches fresh data
+ */
+export async function cached<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  ttl: number = DEFAULT_TTL,
+  force = false
+): Promise<T> {
+  const now = Date.now();
+  const entry = cache.get(key) as CachedEntry<T> | undefined;
+
+  if (!force && entry && entry.expiry > now) {
+    return entry.data;
+  }
+
+  const data = await fetcher();
+  cache.set(key, { expiry: now + ttl, data });
+  return data;
+}
+
+/** Clear a cache entry or the entire cache when no key is provided */
+export function clearCache(key?: string) {
+  if (key) cache.delete(key);
+  else cache.clear();
+}

--- a/guia-turistica-frontend/src/services/bookings.ts
+++ b/guia-turistica-frontend/src/services/bookings.ts
@@ -1,4 +1,5 @@
 import api from '@/lib/api';
+import { cached, clearCache } from '@/lib/cache';
 
 export async function createBooking(p: {
   guideId: string;
@@ -7,15 +8,24 @@ export async function createBooking(p: {
   pricePerDay?: number;
 }) {
   const { data } = await api.post('/bookings', p);
+  clearCache('myBookings');
   return data;
 }
 
-export async function myBookings() {
-  const { data } = await api.get('/bookings/me');
-  return data;
+export async function myBookings(force = false) {
+  return cached(
+    'myBookings',
+    async () => {
+      const { data } = await api.get('/bookings/me');
+      return data;
+    },
+    undefined,
+    force,
+  );
 }
 
 export async function createReview(p: { bookingId: string; rating: number; comment?: string }) {
   const { data } = await api.post('/reviews', p);
+  clearCache('myBookings');
   return data;
 }

--- a/guia-turistica-frontend/src/services/guides.ts
+++ b/guia-turistica-frontend/src/services/guides.ts
@@ -1,10 +1,22 @@
 import api from '@/lib/api';
+import { cached } from '@/lib/cache';
 
 export type GuideCard = {
   id: string; name: string; city: string | null; pricePerDay: number | null; languages: string[];
 };
 
-export async function fetchGuides(): Promise<GuideCard[]> {
-  const { data } = await api.get('/guides');
-  return data;
+/**
+ * Fetch the list of guides. Results are cached for a short period to avoid
+ * repeated network requests when the data doesn't change between views.
+ */
+export async function fetchGuides(force = false): Promise<GuideCard[]> {
+  return cached(
+    'guides',
+    async () => {
+      const { data } = await api.get('/guides');
+      return data as GuideCard[];
+    },
+    undefined,
+    force,
+  );
 }


### PR DESCRIPTION
## Summary
- add in-memory cache helper for frontend API calls
- cache guide list and bookings queries and clear cache on mutations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d601862a88327b1e5b54a29978d94