### PR TITLE
Add guide search filters and frontend integration

### DIFF
--- a/guia-turistica-backend/prisma/seed.ts
+++ b/guia-turistica-backend/prisma/seed.ts
@@ -1,5 +1,5 @@
 import prisma from '../src/prisma';
-import bcrypt from 'bcryptjs';
+import bcrypt from 'bcrypt';
 
 async function main() {
   // catálogos mínimos

--- a/guia-turistica-frontend/src/services/guides.ts
+++ b/guia-turistica-frontend/src/services/guides.ts
@@ -5,15 +5,22 @@ export type GuideCard = {
   id: string; name: string; city: string | null; pricePerDay: number | null; languages: string[];
 };
 
+export interface GuideFilters {
+  q?: string;
+  lang?: string;
+}
+
 /**
- * Fetch the list of guides. Results are cached for a short period to avoid
- * repeated network requests when the data doesn't change between views.
+ * Fetch the list of guides applying optional filters. Results are cached for a
+ * short period to avoid repeated network requests when the data doesn't change
+ * between views.
  */
-export async function fetchGuides(force = false): Promise<GuideCard[]> {
+export async function fetchGuides(filters: GuideFilters = {}, force = false): Promise<GuideCard[]> {
+  const key = `guides:${filters.q ?? ''}:${filters.lang ?? 'all'}`;
   return cached(
-    'guides',
+    key,
     async () => {
-      const { data } = await api.get('/guides');
+      const { data } = await api.get('/guides', { params: filters });
       return data as GuideCard[];
     },
     undefined,


### PR DESCRIPTION
## Summary
- support text and language filters in `/guides` API
- fetch guides from API on GuidesList page with debounced search
- fix seed script bcrypt import

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm run build` (backend)
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689dacabdd34832797d0951ae1e9461a